### PR TITLE
Do not show the popover when opening the plug

### DIFF
--- a/src/Widgets/TZPopover.vala
+++ b/src/Widgets/TZPopover.vala
@@ -131,6 +131,8 @@ public class DateTime.TZPopover : Gtk.Popover {
         main_grid.add (continent_view);
         main_grid.add (new Gtk.Separator (Gtk.Orientation.VERTICAL));
         main_grid.add (city_scrolled);
+        main_grid.show_all ();
+        
         add (main_grid);
     }
 

--- a/src/Widgets/TimeZoneButton.vala
+++ b/src/Widgets/TimeZoneButton.vala
@@ -59,8 +59,7 @@ public class DateTime.TimeZoneButton : Gtk.Button {
         popover = new DateTime.TZPopover ();
         popover.relative_to = this;
         popover.position = Gtk.PositionType.BOTTOM;
-        popover.show_all ();
-
+        
         popover.request_timezone_change.connect ((tz) => {
             request_timezone_change (tz);
         });


### PR DESCRIPTION
Fixes #35.

Do not show the timezone popover when opening the plug.