### PR TITLE
Use wingpanel's gsettings instead of GNOME's

### DIFF
--- a/src/DateTime1.vala
+++ b/src/DateTime1.vala
@@ -38,6 +38,6 @@ public class DateTime.Settings : Granite.Services.Settings {
     public string clock_format { get; set; }
 
     public Settings () {
-        base ("org.gnome.desktop.interface");
+        base ("io.elementary.desktop.wingpanel.datetime");
     }
 }


### PR DESCRIPTION
In case of https://github.com/elementary/wingpanel-indicator-datetime/pull/84