### PR TITLE
More robust error handling around timezones and cities

### DIFF
--- a/src/Parser.vala
+++ b/src/Parser.vala
@@ -61,13 +61,25 @@ public class DateTime.Parser : GLib.Object {
             if (value.has_prefix (continent) == false)
                 continue;
 
-            string city = _(items[2]).split ("/", 2)[1];
-            string key = format_city (city);
-            if (items[3] != null && items[3] != "")
-                if (items[3] != "mainland" && items[3] != "most locations" && _(items[3]) != key)
-                    key = "%s - %s".printf (key, format_city (_(items[3])));
+            string tz_name_field;
+            // Take the original English string if there is something wrong with the translation
+            if (_(items[2]) == null || _(items[2]) == "") {
+                tz_name_field = items[2];
+            } else {
+                tz_name_field = _(items[2]);
+            }
 
-            timezones.set (key, value);
+            string city = tz_name_field.split ("/", 2)[1];
+            if (city != null && city != "") {
+                string key = format_city (city);
+                if (items[3] != null && items[3] != "") {
+                    if (items[3] != "mainland" && items[3] != "most locations" && _(items[3]) != key) {
+                        key = "%s - %s".printf (key, format_city (_(items[3])));
+                    }
+                }
+
+                timezones.set (key, value);
+            }
         }
 
         return timezones;

--- a/src/Widgets/TimeZoneButton.vala
+++ b/src/Widgets/TimeZoneButton.vala
@@ -30,7 +30,9 @@ public class DateTime.TimeZoneButton : Gtk.Button {
         set {
             var values = value.split ("/", 2);
             continent_label.label = values[0];
-            city_label.label = Parser.format_city (values[1]);
+            if (values.length > 1 && values[1] != null) {
+                city_label.label = Parser.format_city (values[1]);
+            }
 
             popover.set_timezone (value);
         }
@@ -59,7 +61,7 @@ public class DateTime.TimeZoneButton : Gtk.Button {
         popover = new DateTime.TZPopover ();
         popover.relative_to = this;
         popover.position = Gtk.PositionType.BOTTOM;
-        
+
         popover.request_timezone_change.connect ((tz) => {
             request_timezone_change (tz);
         });


### PR DESCRIPTION
Fixes #6 

This will be useful even if the map is removed since some of these methods aren't related to the map, just the general loading of the timezones into the popover.