### PR TITLE
Update time picker on time format change

### DIFF
--- a/src/CurrentTimeManager.vala
+++ b/src/CurrentTimeManager.vala
@@ -32,7 +32,11 @@ public class DateTime.CurrentTimeManager : GLib.Object {
         create_next_minute_timeout ();
     }
 
-    public void datetime_has_changed () {
+    public void datetime_has_changed (bool update_immediately = false) {
+        if (update_immediately) {
+            var now_local = new GLib.DateTime.now_local ();
+            time_has_changed (now_local);
+        }
         create_next_minute_timeout ();
     }
 

--- a/src/MainView.vala
+++ b/src/MainView.vala
@@ -185,6 +185,8 @@ public class DateTime.MainView : Gtk.Grid {
             if (pantheon_act != null) {
                 pantheon_act.time_format = new_format;
             }
+
+            ct_manager.datetime_has_changed (true);
         });
 
         setup_time_format.begin ();


### PR DESCRIPTION
The time picker which lists the current time does not update to
reflect the current time format until the next synchronization.
This commit fixes this so that the change happens immediately when
the time format is changed.

Fixes #44