### PR TITLE
MainView: Clean up timezone code and styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 You'll need the following dependencies:
 
-* libgranite-dev
+* libgranite-dev >= 5.0
 * libswitchboard-2.0-dev
 * meson
 * valac

--- a/data/Plug.css
+++ b/data/Plug.css
@@ -1,4 +1,0 @@
-label.auto-timezone-label,
-image.auto-timezone-label {
-    color: @GRAPE_500;
-}

--- a/data/datetime.gresource.xml
+++ b/data/datetime.gresource.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<gresources>
-  <gresource prefix="/io/elementary/switchboard/plug/datetime">
-    <file compressed="true">Plug.css</file>
-  </gresource>
-</gresources>
-

--- a/meson.build
+++ b/meson.build
@@ -24,12 +24,6 @@ if (get_option('regenerate_translation'))
     )
 endif
 
-plug_resources = gnome.compile_resources(
-    'plug_resources',
-    'data/datetime.gresource.xml',
-    source_dir: 'data'
-)
-
 subdir('data')
 subdir('src')
 subdir('po')

--- a/src/MainView.vala
+++ b/src/MainView.vala
@@ -43,9 +43,6 @@ public class DateTime.MainView : Gtk.Grid {
     }
 
     construct {
-        var css_provider = new Gtk.CssProvider ();
-        css_provider.load_from_resource ("/io/elementary/switchboard/plug/datetime/Plug.css");
-
         var network_time_label = new Gtk.Label (_("Network Time:")) {
             xalign = 1
         };
@@ -99,18 +96,20 @@ public class DateTime.MainView : Gtk.Grid {
         time_zone_picker = new DateTime.TimeZoneGrid () {
             hexpand = true
         };
-        time_zone_picker.request_timezone_change.connect (change_tz);
         time_zone_picker.get_style_context ().add_class ("frame");
 
-        var week_number_label = new Gtk.Label (_("Show week numbers:"));
-        week_number_label.xalign = 1;
+        var week_number_label = new Gtk.Label (_("Show week numbers:")) {
+            xalign = 1
+        };
 
-        var week_number_switch = new Gtk.Switch ();
-        week_number_switch.valign = Gtk.Align.CENTER;
-        week_number_switch.halign = Gtk.Align.START;
+        var week_number_switch = new Gtk.Switch () {
+            halign = Gtk.Align.START,
+            valign = Gtk.Align.CENTER
+        };
 
         column_spacing = 12;
         row_spacing = 12;
+
         attach (time_format_label, 0, 0);
         attach (time_format, 1, 0, 3);
         attach (time_zone_label, 0, 1);
@@ -122,6 +121,7 @@ public class DateTime.MainView : Gtk.Grid {
         attach (week_number_switch, 1, 4);
         attach (time_picker, 2, 3);
         attach (date_picker, 3, 3);
+
         show_all ();
 
         var source = SettingsSchemaSource.get_default ();
@@ -137,10 +137,10 @@ public class DateTime.MainView : Gtk.Grid {
             wingpanel_settings.bind ("show-weeks", week_number_switch, "active", SettingsBindFlags.DEFAULT);
         }
 
+        time_zone_picker.request_timezone_change.connect (change_tz);
+
         bool syncing_datetime = false;
-        /*
-         * Setup Time
-         */
+
         time_picker.time_changed.connect (() => {
             var now_local = new GLib.DateTime.now_local ();
             var minutes = time_picker.time.get_minute () - now_local.get_minute ();
@@ -155,9 +155,6 @@ public class DateTime.MainView : Gtk.Grid {
             ct_manager.datetime_has_changed ();
         });
 
-        /*
-         * Setup Date
-         */
         date_picker.notify["date"].connect (() => {
             if (syncing_datetime == true)
                 return;
@@ -186,9 +183,6 @@ public class DateTime.MainView : Gtk.Grid {
             syncing_datetime = false;
         });
 
-        /*
-         * Setup Clock Format
-         */
         clock_settings = new GLib.Settings ("org.gnome.desktop.interface");
         time_format.mode_changed.connect (() => {
             unowned string new_format = time_format.selected == 0 ? "12h" : "24h";
@@ -207,9 +201,6 @@ public class DateTime.MainView : Gtk.Grid {
 
         setup_time_format.begin ();
 
-        /*
-         * Setup Network Time
-         */
         network_time_switch.notify["active"].connect (() => {
             bool active = network_time_switch.active;
             time_picker.sensitive = !active;

--- a/src/MainView.vala
+++ b/src/MainView.vala
@@ -68,10 +68,7 @@ public class DateTime.MainView : Gtk.Grid {
             xalign = 1
         };
 
-        auto_time_zone_icon = new Gtk.Image () {
-            gicon = new ThemedIcon ("location-inactive-symbolic"),
-            pixel_size = 16
-        };
+        auto_time_zone_icon = new Gtk.Image.from_icon_name ("location-inactive-symbolic", Gtk.IconSize.BUTTON);
 
         weak Gtk.StyleContext auto_time_zone_icon_context = auto_time_zone_icon.get_style_context ();
         auto_time_zone_icon_context.add_class ("accent");

--- a/src/MainView.vala
+++ b/src/MainView.vala
@@ -65,7 +65,7 @@ public class DateTime.MainView : Gtk.Grid {
 
         var time_zone_label = new Gtk.Label (_("Time Zone:")) {
             valign = Gtk.Align.START,
-            xalign = 1
+            halign = Gtk.Align.END
         };
 
         auto_time_zone_icon = new Gtk.Image.from_icon_name ("location-inactive-symbolic", Gtk.IconSize.BUTTON);
@@ -96,7 +96,7 @@ public class DateTime.MainView : Gtk.Grid {
         time_zone_picker.get_style_context ().add_class (Gtk.STYLE_CLASS_FRAME);
 
         var week_number_label = new Gtk.Label (_("Show week numbers:")) {
-            xalign = 1
+            halign = Gtk.Align.END
         };
 
         var week_number_switch = new Gtk.Switch () {

--- a/src/MainView.vala
+++ b/src/MainView.vala
@@ -71,7 +71,7 @@ public class DateTime.MainView : Gtk.Grid {
         auto_time_zone_icon = new Gtk.Image.from_icon_name ("location-inactive-symbolic", Gtk.IconSize.BUTTON);
 
         weak Gtk.StyleContext auto_time_zone_icon_context = auto_time_zone_icon.get_style_context ();
-        auto_time_zone_icon_context.add_class ("accent");
+        auto_time_zone_icon_context.add_class (Granite.STYLE_CLASS_ACCENT);
         auto_time_zone_icon_context.add_class ("purple");
 
         var auto_time_zone_switch_label = new Gtk.Label (_("Based on your Location:"));

--- a/src/MainView.vala
+++ b/src/MainView.vala
@@ -44,7 +44,7 @@ public class DateTime.MainView : Gtk.Grid {
 
     construct {
         var network_time_label = new Gtk.Label (_("Network Time:")) {
-            xalign = 1
+            halign = Gtk.Align.END
         };
 
         var network_time_switch = new Gtk.Switch () {
@@ -56,7 +56,7 @@ public class DateTime.MainView : Gtk.Grid {
         var date_picker = new Granite.Widgets.DatePicker ();
 
         var time_format_label = new Gtk.Label (_("Time Format:")) {
-            xalign = 1
+            halign = Gtk.Align.END
         };
 
         time_format = new Granite.Widgets.ModeButton ();
@@ -64,8 +64,8 @@ public class DateTime.MainView : Gtk.Grid {
         time_format.append_text (_("24-hour"));
 
         var time_zone_label = new Gtk.Label (_("Time Zone:")) {
-            valign = Gtk.Align.START,
-            halign = Gtk.Align.END
+            halign = Gtk.Align.END,
+            valign = Gtk.Align.START
         };
 
         auto_time_zone_icon = new Gtk.Image.from_icon_name ("location-inactive-symbolic", Gtk.IconSize.BUTTON);

--- a/src/MainView.vala
+++ b/src/MainView.vala
@@ -93,7 +93,7 @@ public class DateTime.MainView : Gtk.Grid {
         time_zone_picker = new DateTime.TimeZoneGrid () {
             hexpand = true
         };
-        time_zone_picker.get_style_context ().add_class ("frame");
+        time_zone_picker.get_style_context ().add_class (Gtk.STYLE_CLASS_FRAME);
 
         var week_number_label = new Gtk.Label (_("Show week numbers:")) {
             xalign = 1

--- a/src/MainView.vala
+++ b/src/MainView.vala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 elementary, Inc. (https://elementary.io)
+ * Copyright 2014–2021 elementary, Inc. (https://elementary.io)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -46,18 +46,21 @@ public class DateTime.MainView : Gtk.Grid {
         var css_provider = new Gtk.CssProvider ();
         css_provider.load_from_resource ("/io/elementary/switchboard/plug/datetime/Plug.css");
 
-        var network_time_label = new Gtk.Label (_("Network Time:"));
-        network_time_label.xalign = 1;
+        var network_time_label = new Gtk.Label (_("Network Time:")) {
+            xalign = 1
+        };
 
-        var network_time_switch = new Gtk.Switch ();
-        network_time_switch.valign = Gtk.Align.CENTER;
-        network_time_switch.halign = Gtk.Align.START;
+        var network_time_switch = new Gtk.Switch () {
+            halign = Gtk.Align.START,
+            valign = Gtk.Align.CENTER
+        };
 
         var time_picker = new Granite.Widgets.TimePicker ();
         var date_picker = new Granite.Widgets.DatePicker ();
 
-        var time_format_label = new Gtk.Label (_("Time Format:"));
-        time_format_label.xalign = 1;
+        var time_format_label = new Gtk.Label (_("Time Format:")) {
+            xalign = 1
+        };
 
         time_format = new Granite.Widgets.ModeButton ();
         time_format.append_text (_("AM/PM"));
@@ -68,22 +71,20 @@ public class DateTime.MainView : Gtk.Grid {
             xalign = 1
         };
 
-        auto_time_zone_icon = new Gtk.Image ();
-        auto_time_zone_icon.gicon = new ThemedIcon ("location-inactive-symbolic");
-        auto_time_zone_icon.pixel_size = 16;
+        auto_time_zone_icon = new Gtk.Image () {
+            gicon = new ThemedIcon ("location-inactive-symbolic"),
+            pixel_size = 16
+        };
 
-        var auto_time_zone_icon_context = auto_time_zone_icon.get_style_context ();
-        auto_time_zone_icon_context.add_class ("auto-timezone-label");
-        auto_time_zone_icon_context.add_provider (css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+        weak Gtk.StyleContext auto_time_zone_icon_context = auto_time_zone_icon.get_style_context ();
+        auto_time_zone_icon_context.add_class ("accent");
+        auto_time_zone_icon_context.add_class ("purple");
 
         var auto_time_zone_switch_label = new Gtk.Label (_("Based on your Location:"));
 
-        var auto_time_zone_switch = new Gtk.Switch ();
-        auto_time_zone_switch.tooltip_text = _("Automatically updates the time zone when activated");
-
-        var auto_time_zone_switch_context = auto_time_zone_switch.get_style_context ();
-        auto_time_zone_switch_context.add_class ("auto-timezone");
-        auto_time_zone_switch_context.add_provider (css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+        var auto_time_zone_switch = new Gtk.Switch () {
+            tooltip_text = _("Automatically updates the time zone when activated")
+        };
 
         var auto_time_zone_grid = new Gtk.Grid () {
             column_spacing = 12,
@@ -94,10 +95,6 @@ public class DateTime.MainView : Gtk.Grid {
         auto_time_zone_grid.add (auto_time_zone_icon);
         auto_time_zone_grid.add (auto_time_zone_switch_label);
         auto_time_zone_grid.add (auto_time_zone_switch);
-
-        var auto_time_zone_grid_context = auto_time_zone_grid.get_style_context ();
-        auto_time_zone_grid_context.add_class ("auto-timezone-grid");
-        auto_time_zone_grid_context.add_provider (css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
         time_zone_picker = new DateTime.TimeZoneGrid () {
             hexpand = true

--- a/src/meson.build
+++ b/src/meson.build
@@ -14,7 +14,6 @@ switchboard_plugsdir = switchboard_dep.get_pkgconfig_variable('plugsdir', define
 shared_module(
     meson.project_name(),
     plug_files,
-    plug_resources,
     dependencies: [
         dependency('glib-2.0'),
         dependency('gio-2.0'),

--- a/src/meson.build
+++ b/src/meson.build
@@ -18,7 +18,7 @@ shared_module(
         dependency('glib-2.0'),
         dependency('gio-2.0'),
         dependency('gobject-2.0'),
-        dependency('granite'),
+        dependency('granite', version: '>= 5.0.0'),
         dependency('gtk+-3.0'),
         meson.get_compiler('vala').find_library('posix'),
         switchboard_dep,


### PR DESCRIPTION
Follow-up to #61.

- Bumps copyright while we're here
- Modernizes the rest of the code style to match the new code
- Removes unused style classes
- Removes GResourced CSS in favor of new `.accent.purple` class for better dark style support
- Uses `weak Gtk.StyleContext`
- Groups the signal connection with the others