### PR TITLE
MainView: Rework Layout

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# EditorConfig <http://EditorConfig.org>
+root = true
+
+# elementary defaults
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = tab
+indent_style = space
+insert_final_newline = true
+max_line_length = 80
+tab_width = 4
+
+[{*.xml,*.xml.in,*.yml,*.css}]
+tab_width = 2

--- a/src/MainView.vala
+++ b/src/MainView.vala
@@ -104,18 +104,29 @@ public class DateTime.MainView : Gtk.Grid {
             valign = Gtk.Align.CENTER
         };
 
-        var show_date_label = new Gtk.Label (_("Show the date:")) {
+        var week_number_info = new Gtk.Label (_("e.g. in the Calendar app and Panel indicator")) {
+            max_width_chars = 40,
+            wrap = true,
+            xalign = 0
+        };
+        week_number_info.get_style_context ().add_class (Gtk.STYLE_CLASS_DIM_LABEL);
+
+        var panel_header = new Granite.HeaderLabel (_("Show in Panel")) {
             halign = Gtk.Align.END,
-            margin_top = 24
+            margin_top = 12,
+            xalign = 1
+        };
+
+        var show_date_label = new Gtk.Label (_("Date:")) {
+            halign = Gtk.Align.END
         };
 
         var show_date_switch = new Gtk.Switch () {
             halign = Gtk.Align.START,
-            valign = Gtk.Align.CENTER,
-            margin_top = 24
+            valign = Gtk.Align.CENTER
         };
 
-        var show_weekday_label = new Gtk.Label (_("Show the day of the week:")) {
+        var show_weekday_label = new Gtk.Label (_("Day of the week:")) {
             halign = Gtk.Align.END
         };
 
@@ -124,7 +135,7 @@ public class DateTime.MainView : Gtk.Grid {
             valign = Gtk.Align.CENTER
         };
 
-        var show_seconds_label = new Gtk.Label (_("Show seconds:")) {
+        var show_seconds_label = new Gtk.Label (_("Seconds:")) {
             halign = Gtk.Align.END
         };
 
@@ -147,12 +158,14 @@ public class DateTime.MainView : Gtk.Grid {
         attach (date_picker, 3, 3);
         attach (week_number_label, 0, 4);
         attach (week_number_switch, 1, 4);
-        attach (show_date_label, 0, 5);
-        attach (show_date_switch, 1, 5);
-        attach (show_weekday_label, 0, 6);
-        attach (show_weekday_switch, 1, 6);
-        attach (show_seconds_label, 0, 7);
-        attach (show_seconds_switch, 1, 7);
+        attach (week_number_info, 2, 4, 2);
+        attach (panel_header, 0, 5);
+        attach (show_date_label, 0, 6);
+        attach (show_date_switch, 1, 6);
+        attach (show_weekday_label, 0, 7);
+        attach (show_weekday_switch, 1, 7);
+        attach (show_seconds_label, 0, 8);
+        attach (show_seconds_switch, 1, 8);
 
         show_all ();
 

--- a/src/MainView.vala
+++ b/src/MainView.vala
@@ -110,45 +110,30 @@ public class DateTime.MainView : Gtk.ScrolledWindow {
             valign = Gtk.Align.CENTER
         };
 
-        var week_number_info = new Gtk.Label (_("e.g. in the Calendar app and Panel indicator")) {
+        var week_number_info = new Gtk.Label (_("e.g. in Calendar and the Date & Time Panel indicator")) {
             max_width_chars = 40,
             wrap = true,
             xalign = 0
         };
         week_number_info.get_style_context ().add_class (Gtk.STYLE_CLASS_DIM_LABEL);
 
-        var panel_header = new Granite.HeaderLabel (_("Show in Panel")) {
+        var panel_label = new Gtk.Label (_("Show in Panel:")) {
             halign = Gtk.Align.END,
-            margin_top = 12,
-            xalign = 1
+            margin_top = 6
         };
 
-        var show_date_label = new Gtk.Label (_("Date:")) {
-            halign = Gtk.Align.END
+        var date_check = new Gtk.CheckButton.with_label (_("Date"));
+        var weekday_check = new Gtk.CheckButton.with_label (_("Day of the week"));
+        var seconds_check = new Gtk.CheckButton.with_label (_("Seconds"));
+
+        var panel_check_grid = new Gtk.Grid () {
+            column_spacing = 12,
+            margin_top = 6
         };
 
-        var show_date_switch = new Gtk.Switch () {
-            halign = Gtk.Align.START,
-            valign = Gtk.Align.CENTER
-        };
-
-        var show_weekday_label = new Gtk.Label (_("Day of the week:")) {
-            halign = Gtk.Align.END
-        };
-
-        var show_weekday_switch = new Gtk.Switch () {
-            halign = Gtk.Align.START,
-            valign = Gtk.Align.CENTER
-        };
-
-        var show_seconds_label = new Gtk.Label (_("Seconds:")) {
-            halign = Gtk.Align.END
-        };
-
-        var show_seconds_switch = new Gtk.Switch () {
-            halign = Gtk.Align.START,
-            valign = Gtk.Align.CENTER
-        };
+        panel_check_grid.add (date_check);
+        panel_check_grid.add (weekday_check);
+        panel_check_grid.add (seconds_check);
 
         var grid = new Gtk.Grid () {
             column_spacing = 12,
@@ -170,13 +155,8 @@ public class DateTime.MainView : Gtk.ScrolledWindow {
         grid.attach (week_number_label, 0, 4);
         grid.attach (week_number_switch, 1, 4);
         grid.attach (week_number_info, 2, 4, 2);
-        grid.attach (panel_header, 0, 5);
-        grid.attach (show_date_label, 0, 6);
-        grid.attach (show_date_switch, 1, 6);
-        grid.attach (show_weekday_label, 0, 7);
-        grid.attach (show_weekday_switch, 1, 7);
-        grid.attach (show_seconds_label, 0, 8);
-        grid.attach (show_seconds_switch, 1, 8);
+        grid.attach (panel_label, 0, 5);
+        grid.attach (panel_check_grid, 1, 5, 3);
 
         add (grid);
 
@@ -188,20 +168,17 @@ public class DateTime.MainView : Gtk.ScrolledWindow {
         GLib.Settings wingpanel_settings = null;
 
         if (schema == null) {
-            show_date_label.visible = false;
-            show_date_switch.visible = false;
-            show_weekday_label.visible = false;
-            show_weekday_switch.visible = false;
-            show_seconds_label.visible = false;
-            show_seconds_switch.visible = false;
             week_number_label.visible = false;
             week_number_switch.visible = false;
+            week_number_info.visible = false;
+            panel_label.visible = false;
+            panel_check_grid.visible = false;
         } else {
             wingpanel_settings = new GLib.Settings ("io.elementary.desktop.wingpanel.datetime");
-            wingpanel_settings.bind ("clock-show-date", show_date_switch, "active", SettingsBindFlags.DEFAULT);
-            wingpanel_settings.bind ("clock-show-weekday", show_weekday_switch, "active", SettingsBindFlags.DEFAULT);
-            wingpanel_settings.bind ("clock-show-seconds", show_seconds_switch, "active", SettingsBindFlags.DEFAULT);
-            wingpanel_settings.bind ("clock-show-date", show_weekday_switch, "sensitive", SettingsBindFlags.DEFAULT);
+            wingpanel_settings.bind ("clock-show-date", date_check, "active", SettingsBindFlags.DEFAULT);
+            wingpanel_settings.bind ("clock-show-weekday", weekday_check, "active", SettingsBindFlags.DEFAULT);
+            wingpanel_settings.bind ("clock-show-seconds", seconds_check, "active", SettingsBindFlags.DEFAULT);
+            wingpanel_settings.bind ("clock-show-date", weekday_check, "sensitive", SettingsBindFlags.DEFAULT);
             wingpanel_settings.bind ("show-weeks", week_number_switch, "active", SettingsBindFlags.DEFAULT);
         }
 

--- a/src/MainView.vala
+++ b/src/MainView.vala
@@ -51,7 +51,7 @@ public class DateTime.MainView : Gtk.ScrolledWindow {
     }
 
     construct {
-        var network_time_label = new Gtk.Label (_("Network Time:")) {
+        var network_time_label = new Gtk.Label (_("Network time:")) {
             halign = Gtk.Align.END
         };
 
@@ -63,7 +63,7 @@ public class DateTime.MainView : Gtk.ScrolledWindow {
         var time_picker = new Granite.Widgets.TimePicker ();
         var date_picker = new Granite.Widgets.DatePicker ();
 
-        var time_format_label = new Gtk.Label (_("Time Format:")) {
+        var time_format_label = new Gtk.Label (_("Time format:")) {
             halign = Gtk.Align.END
         };
 
@@ -82,7 +82,7 @@ public class DateTime.MainView : Gtk.ScrolledWindow {
         auto_time_zone_icon_context.add_class (Granite.STYLE_CLASS_ACCENT);
         auto_time_zone_icon_context.add_class ("purple");
 
-        var auto_time_zone_switch_label = new Gtk.Label (_("Based on your Location:"));
+        var auto_time_zone_switch_label = new Gtk.Label (_("Based on location:"));
 
         var auto_time_zone_switch = new Gtk.Switch () {
             tooltip_text = _("Automatically updates the time zone when activated")

--- a/src/MainView.vala
+++ b/src/MainView.vala
@@ -95,6 +95,15 @@ public class DateTime.MainView : Gtk.Grid {
         };
         time_zone_picker.get_style_context ().add_class (Gtk.STYLE_CLASS_FRAME);
 
+        var week_number_label = new Gtk.Label (_("Show week numbers:")) {
+            halign = Gtk.Align.END
+        };
+
+        var week_number_switch = new Gtk.Switch () {
+            halign = Gtk.Align.START,
+            valign = Gtk.Align.CENTER
+        };
+
         var show_date_label = new Gtk.Label (_("Show the date:")) {
             halign = Gtk.Align.END,
             margin_top = 24
@@ -124,15 +133,6 @@ public class DateTime.MainView : Gtk.Grid {
             valign = Gtk.Align.CENTER
         };
 
-        var week_number_label = new Gtk.Label (_("Show week numbers:")) {
-            halign = Gtk.Align.END
-        };
-
-        var week_number_switch = new Gtk.Switch () {
-            halign = Gtk.Align.START,
-            valign = Gtk.Align.CENTER
-        };
-
         column_spacing = 12;
         row_spacing = 12;
 
@@ -143,16 +143,16 @@ public class DateTime.MainView : Gtk.Grid {
         attach (auto_time_zone_grid, 1, 2, 3);
         attach (network_time_label, 0, 3);
         attach (network_time_switch, 1, 3);
-        attach (show_date_label, 0, 4);
-        attach (show_date_switch, 1, 4);
-        attach (show_weekday_label, 0, 5);
-        attach (show_weekday_switch, 1, 5);
-        attach (show_seconds_label, 0, 6);
-        attach (show_seconds_switch, 1, 6);
-        attach (week_number_label, 0, 7);
-        attach (week_number_switch, 1, 7);
         attach (time_picker, 2, 3);
         attach (date_picker, 3, 3);
+        attach (week_number_label, 0, 4);
+        attach (week_number_switch, 1, 4);
+        attach (show_date_label, 0, 5);
+        attach (show_date_switch, 1, 5);
+        attach (show_weekday_label, 0, 6);
+        attach (show_weekday_switch, 1, 6);
+        attach (show_seconds_label, 0, 7);
+        attach (show_seconds_switch, 1, 7);
 
         show_all ();
 

--- a/src/MainView.vala
+++ b/src/MainView.vala
@@ -30,8 +30,6 @@ public class DateTime.MainView : Gtk.ScrolledWindow {
 
     public MainView () {
         Object (
-            expand: true,
-            halign: Gtk.Align.FILL,
             hscrollbar_policy: Gtk.PolicyType.NEVER
         );
     }

--- a/src/MainView.vala
+++ b/src/MainView.vala
@@ -69,7 +69,7 @@ public class DateTime.MainView : Gtk.ScrolledWindow {
         time_format.append_text (_("AM/PM"));
         time_format.append_text (_("24-hour"));
 
-        var time_zone_label = new Gtk.Label (_("Time Zone:")) {
+        var time_zone_label = new Gtk.Label (_("Time zone:")) {
             halign = Gtk.Align.END,
             valign = Gtk.Align.START
         };

--- a/src/MainView.vala
+++ b/src/MainView.vala
@@ -17,7 +17,7 @@
  * Authored by: Corentin Noël <corentin@elementaryos.org>
  */
 
-public class DateTime.MainView : Gtk.Grid {
+public class DateTime.MainView : Gtk.ScrolledWindow {
     private Gtk.Image auto_time_zone_icon;
     private TimeZoneGrid time_zone_picker;
     private DateTime1 datetime1;
@@ -27,6 +27,14 @@ public class DateTime.MainView : Gtk.Grid {
     private Pantheon.AccountsService? pantheon_act = null;
 
     private static GLib.Settings time_zone_settings;
+
+    public MainView () {
+        Object (
+            expand: true,
+            halign: Gtk.Align.FILL,
+            hscrollbar_policy: Gtk.PolicyType.NEVER
+        );
+    }
 
     public bool automatic_timezone {
         set {
@@ -144,28 +152,35 @@ public class DateTime.MainView : Gtk.Grid {
             valign = Gtk.Align.CENTER
         };
 
-        column_spacing = 12;
-        row_spacing = 12;
+        var grid = new Gtk.Grid () {
+            column_spacing = 12,
+            halign = Gtk.Align.CENTER,
+            margin_bottom = 24,
+            margin_top = 24,
+            row_spacing = 12
+        };
 
-        attach (time_format_label, 0, 0);
-        attach (time_format, 1, 0, 3);
-        attach (time_zone_label, 0, 1);
-        attach (time_zone_picker, 1, 1, 3);
-        attach (auto_time_zone_grid, 1, 2, 3);
-        attach (network_time_label, 0, 3);
-        attach (network_time_switch, 1, 3);
-        attach (time_picker, 2, 3);
-        attach (date_picker, 3, 3);
-        attach (week_number_label, 0, 4);
-        attach (week_number_switch, 1, 4);
-        attach (week_number_info, 2, 4, 2);
-        attach (panel_header, 0, 5);
-        attach (show_date_label, 0, 6);
-        attach (show_date_switch, 1, 6);
-        attach (show_weekday_label, 0, 7);
-        attach (show_weekday_switch, 1, 7);
-        attach (show_seconds_label, 0, 8);
-        attach (show_seconds_switch, 1, 8);
+        grid.attach (time_format_label, 0, 0);
+        grid.attach (time_format, 1, 0, 3);
+        grid.attach (time_zone_label, 0, 1);
+        grid.attach (time_zone_picker, 1, 1, 3);
+        grid.attach (auto_time_zone_grid, 1, 2, 3);
+        grid.attach (network_time_label, 0, 3);
+        grid.attach (network_time_switch, 1, 3);
+        grid.attach (time_picker, 2, 3);
+        grid.attach (date_picker, 3, 3);
+        grid.attach (week_number_label, 0, 4);
+        grid.attach (week_number_switch, 1, 4);
+        grid.attach (week_number_info, 2, 4, 2);
+        grid.attach (panel_header, 0, 5);
+        grid.attach (show_date_label, 0, 6);
+        grid.attach (show_date_switch, 1, 6);
+        grid.attach (show_weekday_label, 0, 7);
+        grid.attach (show_weekday_switch, 1, 7);
+        grid.attach (show_seconds_label, 0, 8);
+        grid.attach (show_seconds_switch, 1, 8);
+
+        add (grid);
 
         show_all ();
 

--- a/src/MainView.vala
+++ b/src/MainView.vala
@@ -28,12 +28,6 @@ public class DateTime.MainView : Gtk.ScrolledWindow {
 
     private static GLib.Settings time_zone_settings;
 
-    public MainView () {
-        Object (
-            hscrollbar_policy: Gtk.PolicyType.NEVER
-        );
-    }
-
     public bool automatic_timezone {
         set {
             if (value) {
@@ -158,6 +152,7 @@ public class DateTime.MainView : Gtk.ScrolledWindow {
         grid.attach (panel_label, 0, 5);
         grid.attach (panel_check_grid, 1, 5, 3);
 
+        hscrollbar_policy = Gtk.PolicyType.NEVER;
         add (grid);
 
         show_all ();

--- a/src/Plug.vala
+++ b/src/Plug.vala
@@ -35,8 +35,6 @@ public class DateTime.Plug : Switchboard.Plug {
     public override Gtk.Widget get_widget () {
         if (main_view == null) {
             main_view = new DateTime.MainView ();
-            main_view.margin = 24;
-            main_view.halign = Gtk.Align.CENTER;
         }
 
         return main_view;


### PR DESCRIPTION
Fixes #92.

- Changes to ScrolledWindow so the window doesn't expand when coming from a short category view
- Adds help text to week number switch to help explain where it is applied
- Adds heading above panel-specific switches and simplifies their labels
- Sentence-cases other labels while here for consistency

### Before

![Screenshot from 2021-04-07 11-59-40](https://user-images.githubusercontent.com/611168/113912780-c4f2c600-9798-11eb-8a16-ad574b34b980.png)

### After

![Screenshot from 2021-04-07 16-36-55](https://user-images.githubusercontent.com/611168/113943247-802e5580-97bf-11eb-9c0d-52d774662d8f.png)


