### PR TITLE
Fix missing minutes portion of timezone UTC offset

### DIFF
--- a/src/Widgets/TimeZoneGrid.vala
+++ b/src/Widgets/TimeZoneGrid.vala
@@ -148,10 +148,10 @@ public class DateTime.TimeZoneGrid : Gtk.Box {
         var minutes = seconds % 3600 / 60;
 
         if (hours > 0) {
-            return _("UTC +%i.%02i").printf (hours, minutes);
+            return _("UTC +%i:%02i").printf (hours, minutes);
         }
 
         // Make sure we use typographical minus
-        return _("UTC −%i.%02i").printf (hours.abs (), minutes);
+        return _("UTC −%i:%02i").printf (hours.abs (), minutes);
     }
 }

--- a/src/Widgets/TimeZoneGrid.vala
+++ b/src/Widgets/TimeZoneGrid.vala
@@ -152,6 +152,6 @@ public class DateTime.TimeZoneGrid : Gtk.Box {
         }
 
         // Make sure we use typographical minus
-        return _("UTC −%i:%02i").printf (hours.abs (), minutes);
+        return _("UTC −%i:%02i").printf (hours.abs (), minutes.abs ());
     }
 }

--- a/src/Widgets/TimeZoneGrid.vala
+++ b/src/Widgets/TimeZoneGrid.vala
@@ -145,12 +145,13 @@ public class DateTime.TimeZoneGrid : Gtk.Box {
         }
 
         var hours = seconds / 3600;
+        var minutes = seconds % 3600 / 60;
 
         if (hours > 0) {
-            return _("UTC +%i").printf (hours);
+            return _("UTC +%i.%02i").printf (hours, minutes);
         }
 
         // Make sure we use typographical minus
-        return _("UTC −%i").printf (hours.abs ());
+        return _("UTC −%i.%02i").printf (hours.abs (), minutes);
     }
 }


### PR DESCRIPTION
Fixes timezone UTC offset in the `private string seconds_to_utc_offset (int seconds)` method which was showing only the hours portion and now also includes the minutes portion.

Before: `Asia/Kolkata (UTC +5)`

After: `Asia/Kolkata (UTC +5.30)`

For others without minutes it shows like: `blah (UTC +5.00)` which I think is expected.