### PR TITLE
MainView: Correct initial timezone value

### DIFF
--- a/src/MainView.vala
+++ b/src/MainView.vala
@@ -329,14 +329,11 @@ public class DateTime.MainView : Switchboard.SettingsPage {
     }
 
     private void change_tz (string _tz) {
-        var tz = _(_tz);
-        var english_tz = _tz;
+        time_zone_picker.time_zone = _tz;
 
-        time_zone_picker.time_zone = tz;
-
-        if (datetime1.Timezone != english_tz) {
+        if (datetime1.Timezone != _tz) {
             try {
-                datetime1.set_timezone (english_tz, true);
+                datetime1.set_timezone (_tz, true);
             } catch (Error e) {
                 critical (e.message);
             }


### PR DESCRIPTION
Fixes #38

TimeZoneGrid expects untranslated timezone is set in the time_zone property but we're passing translated timezone, resulting no selected timezone when initialized in non-English environment.